### PR TITLE
support sub-url install

### DIFF
--- a/api.php
+++ b/api.php
@@ -8,9 +8,9 @@
  * License URI: http://www.gnu.org/licenses/gpl-3.0.html
  */
 
-require_once($_SERVER['DOCUMENT_ROOT'] . '/wp-config.php');
-require_once($_SERVER['DOCUMENT_ROOT'] . '/wp-includes/option.php');
-require_once($_SERVER['DOCUMENT_ROOT'] . '/wp-includes/capabilities.php');
+require_once($ABSPATH . 'wp-config.php');
+require_once($ABSPATH . 'wp-includes/option.php');
+require_once($ABSPATH . 'wp-includes/capabilities.php');
 
 header('Content-Type:application/json; charset=utf-8');
 

--- a/api.php
+++ b/api.php
@@ -8,9 +8,9 @@
  * License URI: http://www.gnu.org/licenses/gpl-3.0.html
  */
 
-require_once($ABSPATH . 'wp-config.php');
-require_once($ABSPATH . 'wp-includes/option.php');
-require_once($ABSPATH . 'wp-includes/capabilities.php');
+require_once('../../../wp-config.php');
+require_once('../../../wp-includes/option.php');
+require_once('../../../wp-includes/capabilities.php');
 
 header('Content-Type:application/json; charset=utf-8');
 

--- a/index.php
+++ b/index.php
@@ -239,7 +239,7 @@ frameborder="0" height="850" width="800px;" scrolling="No" leftmargin="0" topmar
 </iframe>
 EOT;
         $plugin_root_url = plugin_url();
-        str_replace('/wp-content/plugins', $plugin_root_url, $iframe_str);
+        $iframe_str = str_replace('/wp-content/plugins', $plugin_root_url, $iframe_str);
         echo $iframe_str;
     }
 }

--- a/index.php
+++ b/index.php
@@ -238,7 +238,7 @@ class WP_CHINA_YES {
 frameborder="0" height="850" width="800px;" scrolling="No" leftmargin="0" topmargin="0">
 </iframe>
 EOT;
-        $plugin_root_url = plugin_dir();
+        $plugin_root_url = plugin_url();
         str_replace('/wp-content/plugins', $plugin_root_url, $iframe_str);
         echo $iframe_str;
     }

--- a/index.php
+++ b/index.php
@@ -238,7 +238,7 @@ class WP_CHINA_YES {
 frameborder="0" height="850" width="800px;" scrolling="No" leftmargin="0" topmargin="0">
 </iframe>
 EOT;
-        $plugin_root_url = plugin_url();
+        $plugin_root_url = plugins_url();
         $iframe_str = str_replace('/wp-content/plugins', $plugin_root_url, $iframe_str);
         echo $iframe_str;
     }

--- a/index.php
+++ b/index.php
@@ -232,11 +232,14 @@ class WP_CHINA_YES {
     }
 
     public static function settings() {
-        echo <<<EOT
+        $iframe_str = <<<EOT
 <div style="height: 20px"></div>
-<iframe src="<?php echo plugins_url() ?>/wp-china-yes/settings.html" 
+<iframe src="/wp-content/plugins/wp-china-yes/settings.html" 
 frameborder="0" height="850" width="800px;" scrolling="No" leftmargin="0" topmargin="0">
 </iframe>
 EOT;
+        $plugin_root_url = plugin_dir();
+        str_replace('/wp-content/plugins', $plugin_root_url, $iframe_str);
+        echo $iframe_str;
     }
 }

--- a/index.php
+++ b/index.php
@@ -234,7 +234,7 @@ class WP_CHINA_YES {
     public static function settings() {
         echo <<<EOT
 <div style="height: 20px"></div>
-<iframe src="/wp-content/plugins/wp-china-yes/settings.html" 
+<iframe src="<?php echo plugins_url() ?>/wp-china-yes/settings.html" 
 frameborder="0" height="850" width="800px;" scrolling="No" leftmargin="0" topmargin="0">
 </iframe>
 EOT;

--- a/settings.html
+++ b/settings.html
@@ -130,7 +130,7 @@
       },
       getConfig() {
         let vm = this;
-        let root_url = window.location.href.split('wp-admin')[0]; 
+        let root_url = window.location.href.split('wp-content')[0];
         axios.get(root_url + 'wp-content/plugins/wp-china-yes/api.php?get_config')
             .then(function (response) {
               vm.mirrors_form = response.data.data;
@@ -176,7 +176,7 @@
           data.append('api_server', vm.mirrors_form.api_server);
           data.append('download_server', vm.mirrors_form.download_server);
           
-          let root_url = window.location.href.split('wp-admin')[0];
+          let root_url = window.location.href.split('wp-content')[0];
           axios.post(root_url + 'wp-content/plugins/wp-china-yes/api.php', data)
               .then(function (response) {
                 vm.$message({

--- a/settings.html
+++ b/settings.html
@@ -130,8 +130,8 @@
       },
       getConfig() {
         let vm = this;
-
-        axios.get('/wp-content/plugins/wp-china-yes/api.php?get_config')
+        let root_url = window.location.href.split('wp-admin')[0]; 
+        axios.get(root_url + 'wp-content/plugins/wp-china-yes/api.php?get_config')
             .then(function (response) {
               vm.mirrors_form = response.data.data;
             })
@@ -175,8 +175,9 @@
           data.append('custom_download_server', vm.mirrors_form.custom_download_server);
           data.append('api_server', vm.mirrors_form.api_server);
           data.append('download_server', vm.mirrors_form.download_server);
-
-          axios.post('/wp-content/plugins/wp-china-yes/api.php', data)
+          
+          let root_url = window.location.href.split('wp-admin')[0];
+          axios.post(root_url + 'wp-content/plugins/wp-china-yes/api.php', data)
               .then(function (response) {
                 vm.$message({
                   message: '保存成功',


### PR DESCRIPTION
When wordpress it deployed using sub-url like http://example.org/mysite,
the configuration page cannot be opened with message "The requested URL /wp-content/plugins/wp-china-yes/settings.html was not found on this server."